### PR TITLE
test: set appropriate mapping template version on tests 

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -4,6 +4,7 @@ import { TransactionOperation } from "./dynamo/dynamo"
 import { Query, ConditionExpression, Attribute, ListItem } from "./dynamo/dynamo-conditions"
 
 test("Simple template", () => {
+    Api.setGlobalVersion(MappingTemplateVersion.V1)
     const t = Api.requestTemplate(r => {
         const id = r.variable("ENTITY#" + r.util.autoId())
         r.unless(r.ctx.identity.groups.contains("admins"), () => {
@@ -96,6 +97,7 @@ $!{var0.put("substring", \${var5})}
 })
 
 test("DynamoDB templates", () => {
+    Api.setGlobalVersion(MappingTemplateVersion.V1)
     const put = Api.requestTemplate(r => {
         r.dynamoDb.putItem({
             key: {


### PR DESCRIPTION
For tests that check the full resulting object, including the mapping
template version, we set the appropriate API's mapping template version
before it runs.

We do this because we have some tests that will set V2. By doing so,
every test that runs after them will be V2, even the ones that needs to
be V1 (default).

Signed-off-by: Juliana Oliveira <juliana@uma.ni>